### PR TITLE
Bump progressbar to 2.5

### DIFF
--- a/pkg/lib/CIEInterface.py
+++ b/pkg/lib/CIEInterface.py
@@ -374,7 +374,8 @@ class CIEInterface:
 
         bar = None
         if progressBar:
-            bar = progressbar.ProgressBar(max_value=maxLen)
+            bar = progressbar.ProgressBar(maxLen)
+            bar.start()
 
         dataLen = len(data)
         while dataLen < maxLen:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-pyscard==1.9.6
-progressbar==2.3
+pyscard==1.9.7
+progressbar==2.5
 pyDes==2.0.1


### PR DESCRIPTION
Just did it because I already had that version installed.
I bumped also pyscard, everything works as expected.